### PR TITLE
A fix if the usb_external is bigger than internal_storage

### DIFF
--- a/install-to-internal
+++ b/install-to-internal
@@ -97,18 +97,7 @@ def partition_and_flash():
     print_status("Copying rootfs to internal storage")
     mkdir("/mnt/internal")
     bash(f"sudo mount {internal_name}p2 /mnt/internal")
-    exclude_dirs=[
-        "/mnt/internal", # prevent recursivity issues
-        "/tmp",
-        "/dev",
-        "/sys",
-        "/proc",
-        "/run"
-    ]
-    exclude=""
-    for file in exclude_dirs:
-        exclude=exclude +"--exclude="+file+" "
-    bash(f'rsync -aHAXErp --progress {exclude} / /mnt/internal')
+    bash(f'rsync -aHAXErp --progress --exclude=/mnt/internal --exclude=/tmp --exclude=/dev --exclude=/sys --exclude=/proc --exclude=/run / /mnt/internal')
     bash('umount /mnt/internal')
 
 # Force internal to resize on first boot

--- a/install-to-internal
+++ b/install-to-internal
@@ -99,17 +99,16 @@ def partition_and_flash():
     bash(f"sudo mount {internal_name}p2 /mnt/internal")
     exclude_dirs=[
         "/mnt/internal", # prevent recursivity issues
-        "/tmp"#,
-        #"/dev",
-        #"/sys",
-        #"/proc",
-        #"/run"
+        "/tmp",
+        "/dev",
+        "/sys",
+        "/proc",
+        "/run"
     ]
     exclude=""
     for file in exclude_dirs:
         exclude=exclude +"--exclude="+file+" "
-    print(f'rsync -a {exclude} / /mnt/internal')
-    bash(f'rsync -a {exclude} / /mnt/internal')
+    bash(f'rsync -aHAXErp --progress {exclude} / /mnt/internal')
     bash('umount /mnt/internal')
 
 # Force internal to resize on first boot

--- a/install-to-internal
+++ b/install-to-internal
@@ -99,8 +99,8 @@ def partition_and_flash():
     bash(f"sudo mount {internal_name}p2 /mnt/internal")
     exclude_dirs=[
         "/mnt/internal", # prevent recursivity issues
-        "/tmp",
-        "/dev"#,
+        "/tmp"#,
+        #"/dev",
         #"/sys",
         #"/proc",
         #"/run"

--- a/install-to-internal
+++ b/install-to-internal
@@ -110,6 +110,7 @@ def partition_and_flash():
         exclude=exclude +"--exclude="+file+" "
     print(f'rsync -a {exclude} / /mnt/internal')
     bash(f'rsync -a {exclude} / /mnt/internal')
+    bash('umount /mnt/internal')
 
 # Force internal to resize on first boot
 def post_copy() -> None:

--- a/install-to-internal
+++ b/install-to-internal
@@ -95,8 +95,19 @@ def partition_and_flash():
     bash(f"yes 2>/dev/null | mkfs.ext4 {internal_name}p2")  # 2>/dev/null is to supress yes broken pipe warning
 
     print_status("Copying rootfs to internal storage")
-    bash(f'sudo dd if={src_device}2 of={internal_name}p2 status=progress')
-
+    mkdir("/mnt/internal")
+    bash(f"sudo mount {internal_name}p2 /mnt/internal")
+    exclude_dirs=[
+        "/mnt/internal" # prevent recursivity issues
+        "/tmp"
+        "/dev"
+        "/sys"
+        "/proc"
+    ]
+    exclude=""
+    for file in exclude_dirs:
+        exclude+="--exclude="+file+" "
+    bash(f'rsync -a {exclude} / /mnt/internal')
 
 # Force internal to resize on first boot
 def post_copy() -> None:

--- a/install-to-internal
+++ b/install-to-internal
@@ -102,7 +102,8 @@ def partition_and_flash():
         "/tmp",
         "/dev",
         "/sys",
-        "/proc"
+        "/proc",
+        "/run"
     ]
     exclude=""
     for file in exclude_dirs:

--- a/install-to-internal
+++ b/install-to-internal
@@ -106,7 +106,7 @@ def partition_and_flash():
     ]
     exclude=""
     for file in exclude_dirs:
-        exclude+="--exclude="+file+" "
+        exclude=exclude +"--exclude="+file+" "
     print(f'rsync -a {exclude} / /mnt/internal')
     bash(f'rsync -a {exclude} / /mnt/internal')
 

--- a/install-to-internal
+++ b/install-to-internal
@@ -98,10 +98,10 @@ def partition_and_flash():
     mkdir("/mnt/internal")
     bash(f"sudo mount {internal_name}p2 /mnt/internal")
     exclude_dirs=[
-        "/mnt/internal" # prevent recursivity issues
-        "/tmp"
-        "/dev"
-        "/sys"
+        "/mnt/internal", # prevent recursivity issues
+        "/tmp",
+        "/dev",
+        "/sys",
         "/proc"
     ]
     exclude=""

--- a/install-to-internal
+++ b/install-to-internal
@@ -100,10 +100,10 @@ def partition_and_flash():
     exclude_dirs=[
         "/mnt/internal", # prevent recursivity issues
         "/tmp",
-        "/dev",
-        "/sys",
-        "/proc",
-        "/run"
+        "/dev"#,
+        #"/sys",
+        #"/proc",
+        #"/run"
     ]
     exclude=""
     for file in exclude_dirs:

--- a/install-to-internal
+++ b/install-to-internal
@@ -107,6 +107,7 @@ def partition_and_flash():
     exclude=""
     for file in exclude_dirs:
         exclude+="--exclude="+file+" "
+    print(f'rsync -a {exclude} / /mnt/internal')
     bash(f'rsync -a {exclude} / /mnt/internal')
 
 # Force internal to resize on first boot


### PR DESCRIPTION
This fix is in the case which the usb_external is bigger than internal_storage (so dd return an error). So I use rsync (and exclude some directory). By the way, it should be faster.